### PR TITLE
Provide separate "production" and "dev" profiles

### DIFF
--- a/src/conf.ml
+++ b/src/conf.ml
@@ -1,3 +1,9 @@
+let profile =
+  match Sys.getenv_opt "CI_PROFILE" with
+  | Some "production" -> `Production
+  | Some "dev" | None -> `Dev
+  | Some x -> Fmt.failwith "Unknown $PROFILE setting %S" x
+
 module Capnp = struct
   (* Cap'n Proto RPC is enabled by passing --capnp-public-address. These values are hard-coded
      (because they're just internal to the Docker container). *)

--- a/src/main.ml
+++ b/src/main.ml
@@ -4,7 +4,10 @@ module Rpc = Current_rpc.Impl(Current)
 
 let () =
   Logging.init ();
-  Nocrypto_entropy_lwt.initialize () |> ignore
+  Nocrypto_entropy_lwt.initialize () |> ignore;
+  match Conf.profile with
+  | `Production -> Logs.info (fun f -> f "Using production configuration")
+  | `Dev -> Logs.info (fun f -> f "Using dev configuration")
 
 let webhooks = [
   "github", Current_github.input_webhook

--- a/src/pipeline.ml
+++ b/src/pipeline.ml
@@ -4,8 +4,13 @@ module Git = Current_git
 module Github = Current_github
 module Docker = Current_docker.Default
 
+let pool_size =
+  match Conf.profile with
+  | `Production -> 20
+  | `Dev -> 1
+
 (* Limit number of concurrent builds. *)
-let pool = Lwt_pool.create 20 Lwt.return
+let pool = Lwt_pool.create pool_size Lwt.return
 
 (* Maximum time for one Docker build. *)
 let timeout = Duration.of_hour 1

--- a/stack.yml
+++ b/stack.yml
@@ -9,6 +9,8 @@ services:
   ci:
     image: ocaml-ci
     command: --github-app-id 39151 --github-private-key-file /run/secrets/ocaml-ci-github-key --github-account-whitelist "talex5,ocaml-ci,ocaml,mirage,avsm,samoht,kit-ty-kate,tarides,aantron" --confirm above-average --confirm-auto-release 120 --capnp-address=base-images.ocamllabs.io:8102
+    environment:
+      - "CI_PROFILE=production"
     ports:
       - '8102:9000'
     volumes:


### PR DESCRIPTION
Set `$CI_PROFILE` to choose. This avoids having to keep modifying the code to configure a smaller pool size for local testing.