### PR TITLE
Add basic frontend web-ui

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ COPY --chown=opam \
 	ocurrent/current_rpc.opam \
 	/src/ocurrent/
 RUN opam pin -y add /src/ocurrent
-COPY --chown=opam ocaml-ci-service.opam /src/
+COPY --chown=opam ocaml-ci-service.opam ocaml-ci-api.opam /src/
 WORKDIR /src
 RUN opam install -y --deps-only .
 ADD --chown=opam . .

--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -1,0 +1,18 @@
+FROM ocurrent/opam:debian-10-ocaml-4.08 AS build
+RUN sudo apt-get update && sudo apt-get install capnproto m4 pkg-config libgmp-dev -y --no-install-recommends
+RUN cd ~/opam-repository && git pull origin master && git reset --hard 8bc187ff7168b47537d5bbd9b330a90ed90830ad && opam update
+COPY --chown=opam \
+	ocurrent/current_rpc.opam \
+	/src/ocurrent/
+RUN opam pin -yn add /src/ocurrent
+COPY --chown=opam ocaml-ci-api.opam ocaml-ci-web.opam /src/
+WORKDIR /src
+RUN opam install -y --deps-only .
+ADD --chown=opam . .
+RUN opam config exec -- dune build ./_build/install/default/bin/ocaml-ci-web
+
+FROM debian:10
+RUN apt-get update && apt-get install dumb-init -y --no-install-recommends
+WORKDIR /
+ENTRYPOINT ["dumb-init", "/usr/local/bin/ocaml-ci-web"]
+COPY --from=build /src/_build/install/default/bin/ocaml-ci-web /usr/local/bin/

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,13 @@
 CONTEXT := ci.ocamllabs.io
 
 all:
-	dune build ./service/main.exe ./client/main.exe
+	dune build ./service/main.exe ./client/main.exe ./web-ui/main.exe
 
-deploy:
+deploy-backend:
 	docker --context $(CONTEXT) build -t ocaml-ci-service .
+
+deploy-web:
+	docker --context $(CONTEXT) build -f Dockerfile.web -t ocaml-ci-web .
 
 deploy-stack:
 	docker --context $(CONTEXT) stack deploy --prune -c stack.yml ocaml-ci

--- a/dune
+++ b/dune
@@ -1,1 +1,2 @@
 (dirs :standard \ var)
+(vendored_dirs capnp-ocaml capnp-rpc ocurrent)

--- a/ocaml-ci-web.opam
+++ b/ocaml-ci-web.opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "-p" name "@doc"] {with-doc}
+]
+maintainer: ["talex5@gmail.com"]
+authors: ["talex5@gmail.com"]
+bug-reports: "https://github.com/talex5/ocaml-ci/issues"
+homepage: "https://github.com/talex5/ocaml-ci"
+dev-repo: "git+https://github.com/talex5/ocaml-ci.git"
+synopsis: "Web-server frontend for ocaml-ci"
+depends: [
+  "dune" {>= "1.11"}
+  "current_rpc"
+  "prometheus-app"
+  "cmdliner"
+  "lwt"
+  "cohttp-lwt-unix" {>= "2.2.0"}
+  "tyxml"
+  "capnp-rpc-unix"
+  "ocaml-ci-api"
+  "dockerfile"
+]

--- a/stack.yml
+++ b/stack.yml
@@ -19,3 +19,12 @@ services:
       - 'capnp-secrets:/capnp-secrets'
     secrets:
       - 'ocaml-ci-github-key'
+    sysctls:
+      - 'net.ipv4.tcp_keepalive_time=60'
+  web:
+    image: ocaml-ci-web
+    command: --backend /capnp-secrets/ocaml-ci-admin.cap --listen-prometheus=9090
+    volumes:
+      - 'capnp-secrets:/capnp-secrets:ro'
+    sysctls:
+      - 'net.ipv4.tcp_keepalive_time=60'

--- a/web-ui/backend.ml
+++ b/web-ui/backend.ml
@@ -1,0 +1,62 @@
+open Capnp_rpc_lwt
+open Lwt.Infix
+
+let retry_delay = 5.0   (* Time to wait after a failed connection before retrying. *)
+
+module Metrics = struct
+  open Prometheus
+
+  let namespace = "ocamlci"
+  let subsystem = "web"
+
+  let backend_down =
+    let help = "Whether the connection to the backend is down" in
+    Gauge.v ~help ~namespace ~subsystem "backend_down"
+end
+
+type t = {
+  sr : Ocaml_ci_api.Raw.Client.CI.t Sturdy_ref.t;
+  mutable ci : Ocaml_ci_api.Client.CI.t Lwt.t;
+  mutable last_failed : float;
+}
+
+let rec reconnect t =
+  Prometheus.Gauge.set Metrics.backend_down 1.0;
+  let now = Unix.gettimeofday () in
+  let delay = t.last_failed +. retry_delay -. now in
+  t.last_failed <- now;
+  Lwt.async (fun () ->
+      begin if delay > 0.0 then Lwt_unix.sleep delay else Lwt.return_unit end
+      >>= fun () ->
+      Log.info (fun f -> f "Reconnecting to backend");
+      let ci =
+        try Sturdy_ref.connect_exn t.sr
+        with ex -> Lwt.fail ex    (* (just in case) *)
+      in
+      t.ci <- ci;
+      monitor t;
+      Lwt.return_unit
+    )
+and monitor t =
+  Lwt.on_any t.ci
+    (fun ci ->
+       (* Connected OK - now watch for failure. *)
+       Prometheus.Gauge.set Metrics.backend_down 0.0;
+       ci |> Capability.when_broken @@ fun ex ->
+       Log.warn (fun f -> f "Lost connection to backend: %a" Capnp_rpc.Exception.pp ex);
+       reconnect t
+    )
+    (fun ex ->
+       (* Failed to connect. *)
+       Log.warn (fun f -> f "Failed to connect to backend: %a" Fmt.exn ex);
+       reconnect t
+    )
+
+let make sr =
+  let ci = Sturdy_ref.connect_exn sr in
+  let t = { sr; ci; last_failed = 0.0 } in
+  Prometheus.Gauge.set Metrics.backend_down 1.0;
+  monitor t;
+  t
+
+let ci t = t.ci

--- a/web-ui/backend.mli
+++ b/web-ui/backend.mli
@@ -1,0 +1,7 @@
+open Capnp_rpc_lwt
+
+type t
+
+val make : Ocaml_ci_api.Raw.Client.CI.t Sturdy_ref.t -> t
+
+val ci : t -> Ocaml_ci_api.Client.CI.t Lwt.t

--- a/web-ui/dune
+++ b/web-ui/dune
@@ -1,0 +1,12 @@
+(executable
+  (name main)
+  (public_name ocaml-ci-web)
+  (package ocaml-ci-web)
+  (libraries lwt.unix
+             logs.fmt
+             fmt.tty
+             cohttp-lwt-unix
+             tyxml
+             prometheus-app.unix
+             ocaml-ci-api
+             capnp-rpc-unix))

--- a/web-ui/github.ml
+++ b/web-ui/github.ml
@@ -1,0 +1,103 @@
+open Lwt.Infix
+
+module Capability = Capnp_rpc_lwt.Capability
+module Client = Ocaml_ci_api.Client
+module Server = Cohttp_lwt_unix.Server
+module Response = Cohttp.Response.Make(Server.IO)
+module Transfer_IO = Cohttp__Transfer_io.Make(Server.IO)
+
+let errorf fmt =
+  fmt |> Fmt.kstrf @@ fun msg -> Error (`Msg msg)
+
+let normal_response x =
+  x >|= fun x -> `Response x
+
+let respond_error status body =
+  let headers = Cohttp.Header.init_with "Content-Type" "text/plain" in
+  Server.respond_error ~status ~headers ~body () |> normal_response
+
+let commit_url ~owner ~name commit =
+  Printf.sprintf "/github/%s/%s/commit/%s" owner name commit
+
+let format_refs ~owner ~name refs =
+  let open Tyxml.Html in
+  ul (
+    Client.Ref_map.to_seq refs |> List.of_seq |> List.map @@ fun (branch, commit) ->
+    li [a ~a:[a_href (commit_url ~owner ~name commit)] [txt branch]]
+  )
+
+let with_ref r fn =
+  Lwt.finalize
+    (fun () -> fn r)
+    (fun () -> Capnp_rpc_lwt.Capability.dec_ref r; Lwt.return_unit)
+
+let stream_logs job (data, next) writer =
+  let header, footer =
+    let body = Template.instance Tyxml.Html.[
+        pre [txt "@@@"]
+      ] in
+    Astring.String.cut ~sep:"@@@" body |> Option.get
+  in
+  Transfer_IO.write writer (header ^ data) >>= fun () ->
+  let rec aux next =
+    Current_rpc.Job.log job ~start:next >>= function
+    | Ok ("", _) ->
+      Transfer_IO.write writer footer
+    | Ok (data, next) ->
+      Transfer_IO.write writer data >>= fun () ->
+      aux next
+    | Error (`Capnp ex) ->
+      Log.warn (fun f -> f "Error fetching logs: %a" Capnp_rpc.Error.pp ex);
+      Transfer_IO.write writer (Fmt.strf "ocaml-ci error: %a@." Capnp_rpc.Error.pp ex)
+  in
+  aux next
+
+let repo_get ~owner ~name ~repo = function
+  | [] ->
+    begin
+      Client.Repo.refs repo >>= function
+      | Error `Capnp ex -> respond_error `Bad_request (Fmt.to_to_string Capnp_rpc.Error.pp ex)
+      | Ok refs ->
+        let body = Template.instance [
+            format_refs ~owner ~name refs
+          ] in
+        Server.respond_string ~status:`OK ~body () |> normal_response
+    end
+  | ["commit"; commit] ->
+    begin
+      with_ref (Client.Repo.job_of_commit repo commit) @@ fun job ->
+      Current_rpc.Job.log job ~start:0L >>= function
+      | Error `Capnp ex -> respond_error `Bad_request (Fmt.to_to_string Capnp_rpc.Error.pp ex)
+      | Ok chunk ->
+        let headers =
+          (* Otherwise, an nginx reverse proxy will wait for the whole log before sending anything. *)
+          Cohttp.Header.init_with "X-Accel-Buffering" "no"
+        in
+        let res = Cohttp.Response.make ~status:`OK ~flush:true ~encoding:Cohttp.Transfer.Chunked ~headers () in
+        let write _ic oc =
+          let flush = Cohttp.Response.flush res in
+          let writer = Transfer_IO.make_writer ~flush Cohttp.Transfer.Chunked oc in
+          Lwt.finalize
+            (fun () ->
+               stream_logs job chunk writer >>= fun () ->
+               Server.IO.write oc "0\r\n\r\n"
+            )
+            (fun () ->
+               Capability.dec_ref job;
+               Lwt.return_unit
+            )
+        in
+        Capability.inc_ref job;
+        Lwt.return (`Expert (res, write))
+    end
+  | _ ->
+      Server.respond_not_found () |> normal_response
+
+let get ~backend = function
+  | owner :: name :: path ->
+    Backend.ci backend >>= fun ci ->
+    with_ref (Client.CI.org ci owner) @@ fun org ->
+    with_ref (Client.Org.repo org name) @@ fun repo ->
+    repo_get ~owner ~name ~repo path
+  | _ ->
+    Server.respond_not_found () |> normal_response

--- a/web-ui/homepage.ml
+++ b/web-ui/homepage.ml
@@ -1,0 +1,12 @@
+open Tyxml.Html
+
+let render () =
+  Template.instance [
+    p [txt "Welcome to OCaml-CI!"];
+    p [txt "See ";
+       a ~a:[a_href "https://github.com/apps/ocaml-ci"] [
+         txt "The OCaml-CI GitHub App"
+       ];
+       txt " for details.";
+      ];
+  ]

--- a/web-ui/log.ml
+++ b/web-ui/log.ml
@@ -1,0 +1,2 @@
+let src = Logs.Src.create "ocaml_ci_web" ~doc:"ocaml-ci web interface"
+include (val Logs.src_log src : Logs.LOG)

--- a/web-ui/logging.ml
+++ b/web-ui/logging.ml
@@ -1,0 +1,41 @@
+module Metrics = struct
+  open Prometheus
+
+  let namespace = "ocamlci"
+
+  let subsystem = "logs"
+
+  let inc_messages =
+    let help = "Total number of messages logged" in
+    let c =
+      Counter.v_labels ~label_names:[ "level"; "src" ] ~help ~namespace
+        ~subsystem "messages_total"
+    in
+    fun lvl src ->
+      let lvl = Logs.level_to_string (Some lvl) in
+      Counter.inc_one @@ Counter.labels c [ lvl; src ]
+end
+
+let pp_timestamp f x =
+  let open Unix in
+  let tm = localtime x in
+  Fmt.pf f "%04d-%02d-%02d %02d:%02d.%02d" (tm.tm_year + 1900) (tm.tm_mon + 1)
+    tm.tm_mday tm.tm_hour tm.tm_min tm.tm_sec
+
+let reporter =
+  let report src level ~over k msgf =
+    let k _ = over (); k () in
+    let src = Logs.Src.name src in
+    Metrics.inc_messages level src;
+    msgf @@ fun ?header ?tags:_ fmt ->
+    Fmt.kpf k Fmt.stdout ("%a %a %a @[" ^^ fmt ^^ "@]@.")
+      pp_timestamp (Unix.gettimeofday ())
+      Fmt.(styled `Magenta string) (Printf.sprintf "%14s" src)
+      Logs_fmt.pp_header (level, header)
+  in
+  { Logs.report = report }
+
+let init () =
+  Fmt_tty.setup_std_outputs ();
+  Logs.(set_level (Some Info));
+  Logs.set_reporter reporter

--- a/web-ui/main.ml
+++ b/web-ui/main.ml
@@ -1,0 +1,78 @@
+open Lwt.Infix
+open Astring
+
+let () =
+  Logging.init ()
+
+module Server = Cohttp_lwt_unix.Server
+
+let errorf fmt =
+  fmt |> Fmt.kstrf @@ fun msg -> Error (`Msg msg)
+
+let normal_response x =
+  x >|= fun x -> `Response x
+
+let handle_request ~backend _conn request _body =
+  let meth = Cohttp.Request.meth request in
+  let uri = Cohttp.Request.uri request in
+  let path = Uri.path uri in
+  Log.info (fun f -> f "HTTP %s %S" (Cohttp.Code.string_of_method meth) path);
+  match meth, String.cuts ~sep:"/" ~empty:false path with
+  | `GET, ([] | ["index.html"]) ->
+    let body = Homepage.render () in
+    Server.respond_string ~status:`OK ~body () |> normal_response
+  | `GET, ["css"; "style.css"] ->
+    Style.get () |> normal_response
+  | `GET, ("github" :: path) ->
+    Github.get ~backend path
+  | _ ->
+    Server.respond_not_found () |> normal_response
+
+let pp_mode f mode =
+  Sexplib.Sexp.pp_hum f (Conduit_lwt_unix.sexp_of_server mode)
+
+let main port backend_uri prometheus_config =
+  Lwt_main.run begin
+    let vat = Capnp_rpc_unix.client_only_vat () in
+    let backend_sr = Capnp_rpc_unix.Vat.import_exn vat backend_uri in
+    let backend = Backend.make backend_sr in
+    let config = Server.make_response_action ~callback:(handle_request ~backend) () in
+    let mode = `TCP (`Port port) in
+    Log.info (fun f -> f "Starting web server: %a" pp_mode mode);
+    let web =
+      Lwt.try_bind
+        (fun () -> Server.create ~mode config)
+        (fun () -> failwith "Web-server stopped!")
+        (function
+          | Unix.Unix_error(Unix.EADDRINUSE, "bind", _) ->
+            Fmt.failwith "Web-server failed.@ Another program is already using this port %a." pp_mode mode
+          | ex -> Lwt.fail ex
+        )
+    in
+    Lwt.choose (web :: Prometheus_unix.serve prometheus_config)
+  end
+
+open Cmdliner
+
+let port =
+  Arg.value @@
+  Arg.opt Arg.int 8090 @@
+  Arg.info
+    ~doc:"The port on which to listen for incoming HTTP connections."
+    ~docv:"PORT"
+    ["port"]
+
+let backend_cap =
+  Arg.required @@
+  Arg.opt (Arg.some Capnp_rpc_unix.sturdy_uri) None @@
+  Arg.info
+    ~doc:"The capability file giving access to the CI backend service."
+    ~docv:"CAP"
+    ["backend"]
+
+let cmd =
+  let doc = "A web front-end for OCaml-CI" in
+  Term.(const main $ port $ backend_cap $ Prometheus_unix.opts),
+  Term.info "ocaml-ci-web" ~doc
+
+let () = Term.(exit @@ eval cmd)

--- a/web-ui/style.ml
+++ b/web-ui/style.ml
@@ -1,0 +1,107 @@
+module Server = Cohttp_lwt_unix.Server
+
+let css = {|
+  body {
+    margin: 0;
+    padding: 0;
+  }
+
+  nav {
+    margin: 0;
+    padding: 0.1em;
+    display: block;
+    background: black;
+    color: #ddd;
+  }
+
+  nav ul {
+    list-style-type: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  nav li {
+    display: inline;
+  }
+
+  nav li:hover {
+    background: yellow;
+  }
+
+  nav a {
+    color: #ddd;
+    text-decoration: none;
+    padding-left: 0.5em;
+    padding-right: 0.5em;
+  }
+
+  nav a:hover {
+    color: black;
+  }
+
+  div#main {
+    margin: 0.5em;
+  }
+
+  div#main object {
+    max-width: 100%;
+  }
+
+  table.table {
+    border: 1px solid black;
+    padding: 0;
+  }
+
+  table.table th {
+    background: #888;
+    color: white;
+    padding: 0.1em;
+  }
+
+  form {
+    padding: 0.2em;
+  }
+
+  pre span.fg-black   { color: rgb(0, 0, 0) }
+  pre span.fg-red     { color: rgb(205, 0, 0) }
+  pre span.fg-green   { color: rgb(0, 205, 0) }
+  pre span.fg-yellow  { color: rgb(205, 205, 0) }
+  pre span.fg-blue    { color: rgb(0, 0, 238) }
+  pre span.fg-magenta { color: rgb(205, 0, 205) }
+  pre span.fg-cyan    { color: rgb(0, 205, 205) }
+  pre span.fg-white   { color: rgb(229, 229, 229) }
+
+  pre span.fg-bright-black   { color: rgb(127, 127, 127) }
+  pre span.fg-bright-red     { color: rgb(255, 0, 0) }
+  pre span.fg-bright-green   { color: rgb(0, 255, 0) }
+  pre span.fg-bright-yellow  { color: rgb(255, 255, 0) }
+  pre span.fg-bright-blue    { color: rgb(92, 92, 255) }
+  pre span.fg-bright-magenta { color: rgb(255, 0, 255) }
+  pre span.fg-bright-cyan    { color: rgb(0, 255, 255) }
+  pre span.fg-bright-white   { color: rgb(255, 255, 255) }
+
+  pre span.bg-black   { background: rgb(0, 0, 0) }
+  pre span.bg-red     { background: rgb(205, 0, 0) }
+  pre span.bg-green   { background: rgb(0, 205, 0) }
+  pre span.bg-yellow  { background: rgb(205, 205, 0) }
+  pre span.bg-blue    { background: rgb(0, 0, 238) }
+  pre span.bg-magenta { background: rgb(205, 0, 205) }
+  pre span.bg-cyan    { background: rgb(0, 205, 205) }
+  pre span.bg-white   { background: rgb(229, 229, 229) }
+
+  pre span.bg-bright-black   { background: rgb(127, 127, 127) }
+  pre span.bg-bright-red     { background: rgb(255, 0, 0) }
+  pre span.bg-bright-green   { background: rgb(0, 255, 0) }
+  pre span.bg-bright-yellow  { background: rgb(255, 255, 0) }
+  pre span.bg-bright-blue    { background: rgb(92, 92, 255) }
+  pre span.bg-bright-magenta { background: rgb(255, 0, 255) }
+  pre span.bg-bright-cyan    { background: rgb(0, 255, 255) }
+  pre span.bg-bright-white   { background: rgb(255, 255, 255) }
+
+  pre { margin-bottom: 2em }
+|}
+
+let get () =
+  let headers = Cohttp.Header.init_with "Content-Type" "text/css" in
+  Server.respond_string ~status:`OK ~headers ~body:css ()
+(*   Server.respond_file ~fname:"style.css" () *)

--- a/web-ui/template.ml
+++ b/web-ui/template.ml
@@ -1,0 +1,21 @@
+open Tyxml.Html
+
+let html_to_string = Fmt.to_to_string (Tyxml.Html.pp ())
+
+let instance contents =
+  html_to_string (
+    html
+      (head (title (txt "OCaml-CI")) [
+          link ~rel:[ `Stylesheet ] ~href:"/css/style.css" ();
+        ]
+      )
+      (body [
+          nav [
+            ul [
+              li [a ~a:[a_href "/"] [txt "OCaml-CI"]];
+            ]
+          ];
+          div ~a:[a_id "main"] contents
+        ]
+      )
+  )


### PR DESCRIPTION
This uses the Cap'n Proto RPC API to talk to the backend CI service. There are two useful pages so far:

- `/github/$owner/$name` will list the refs being tracked.
- `/github/$owner/$name/commit/$hash` will show the log.

For in-progress builds, it follows the log.

Also, configure TCP keep-alive timeouts for Docker libnetwork.