### PR TITLE
Add build cache for duniverse projects

### DIFF
--- a/service/analyse.ml
+++ b/service/analyse.ml
@@ -8,7 +8,7 @@ let is_directory x =
   | exception Unix.Unix_error (Unix.ENOENT, _, _) -> false
 
 let is_empty_file x =
-  match Unix.lstat (Fpath.to_string x) with
+  match Unix.lstat x with
   | Unix.{ st_kind = S_REG; st_size = 0; _ } -> true
   | _ -> false
 
@@ -53,7 +53,8 @@ module Examine = struct
       |> List.filter (function
           | "" -> false
           | path ->
-            if is_empty_file Fpath.(tmpdir / path) then (
+            let full_path = Filename.concat (Fpath.to_string tmpdir) path in
+            if is_empty_file full_path then (
               Current.Job.log job "WARNING: ignoring empty opam file %S" path;
               false
             ) else

--- a/service/analyse.ml
+++ b/service/analyse.ml
@@ -1,6 +1,12 @@
 open Lwt.Infix
 open Current.Syntax
 
+let is_directory x =
+  match Unix.lstat x with
+  | Unix.{ st_kind = S_DIR; _ } -> true
+  | _ -> false
+  | exception Unix.Unix_error (Unix.ENOENT, _, _) -> false
+
 module Examine = struct
   type t = No_context
 
@@ -12,6 +18,7 @@ module Examine = struct
 
   module Value = struct
     type t = {
+      is_duniverse : bool;
       opam_files : string list;
     }
     [@@deriving yojson]
@@ -24,6 +31,8 @@ module Examine = struct
       | Error e -> failwith e
 
     let opam_files t = t.opam_files
+
+    let is_duniverse t = t.is_duniverse
   end
 
   let id = "ci-analyse"
@@ -31,11 +40,13 @@ module Examine = struct
   let build ~switch No_context job src =
     Current.Job.start job ~level:Current.Level.Harmless >>= fun () ->
     Current_git.with_checkout ~switch ~job src @@ fun tmpdir ->
+    let is_duniverse = is_directory (Filename.concat (Fpath.to_string tmpdir) "duniverse") in
     let cmd = "", [| "find"; "-name"; "*.opam" |] in
     Current.Process.check_output ~cwd:tmpdir ~switch ~job cmd >|= Stdlib.Result.map @@ fun output ->
     let opam_files = String.split_on_char '\n' output |> List.filter ((<>) "") in
-    Current.Job.log job "Found: %a" Fmt.(Dump.list (quote string)) opam_files;
-    { Value.opam_files }
+    let r = { Value.opam_files; is_duniverse } in
+    Current.Job.log job "@[<v2>Results:@,%a@]" Yojson.Safe.(pretty_print ~std:true) (Value.to_yojson r);
+    r
 
   let pp f _ = Fmt.string f "Analyse"
 

--- a/service/analyse.mli
+++ b/service/analyse.mli
@@ -2,6 +2,7 @@ module Analysis : sig
   type t
 
   val opam_files : t -> string list
+  val is_duniverse : t -> bool
 end
 
 val examine : Current_git.Commit.t Current.t -> Analysis.t Current.t

--- a/service/opam_build.ml
+++ b/service/opam_build.ml
@@ -39,6 +39,7 @@ let download_cache = "--mount=type=cache,target=/home/opam/.opam/download-cache,
 
 let dockerfile ~base ~info =
   let opam_files = Analyse.Analysis.opam_files info in
+  if opam_files = [] then failwith "No opam files found!";
   let groups = group_opam_files opam_files in
   let dirs = groups |> List.map (fun (dir, _) -> Printf.sprintf "%S" (Fpath.to_string dir)) |> String.concat " " in
   let open Dockerfile in

--- a/service/opam_build.ml
+++ b/service/opam_build.ml
@@ -2,6 +2,22 @@ module Docker = Current_docker.Default
 
 let crunch_list items = Dockerfile.(crunch (empty @@@ items))
 
+let safe_char = function
+  | 'A'..'Z' | 'a'..'z' | '0'..'9' | '-' | '_' -> true
+  | _ -> false
+
+let check_safe s =
+  if not (Astring.String.for_all safe_char s) then
+    Fmt.failwith "Unsafe characters in %S" s
+
+let build_cache repo =
+  let { Current_github.Repo_id.owner; name } = repo in
+  check_safe owner;
+  check_safe name;
+  Printf.sprintf
+    "--mount=type=cache,target=/src/_build,uid=1000,sharing=private,id=dune:%s:%s"
+    owner name
+
 (* Group opam files by directory.
    e.g. ["a/a1.opam"; "a/a2.opam"; "b/b1.opam"] ->
         [("a", ["a/a1.opam"; "a/a2.opam"]);
@@ -37,10 +53,14 @@ let pin_opam_files groups =
 
 let download_cache = "--mount=type=cache,target=/home/opam/.opam/download-cache,uid=1000"
 
-let dockerfile ~base ~info =
+let dockerfile ~base ~info ~repo =
   let opam_files = Analyse.Analysis.opam_files info in
   if opam_files = [] then failwith "No opam files found!";
   let groups = group_opam_files opam_files in
+  let caches =
+    if Analyse.Analysis.is_duniverse info then Printf.sprintf "%s %s" download_cache (build_cache repo)
+    else download_cache
+  in
   let dirs = groups |> List.map (fun (dir, _) -> Printf.sprintf "%S" (Fpath.to_string dir)) |> String.concat " " in
   let open Dockerfile in
   comment "syntax = docker/dockerfile:experimental" @@
@@ -50,4 +70,4 @@ let dockerfile ~base ~info =
   pin_opam_files groups @@
   run "%s opam install %s --show-actions --deps-only -t | awk '/- install/{print $3}' | xargs opam depext -iy" download_cache dirs @@
   copy ~chown:"opam" ~src:["."] ~dst:"/src/" () @@
-  run "%s opam install -tv ." download_cache
+  run "%s opam install -tv ." caches

--- a/service/opam_build.mli
+++ b/service/opam_build.mli
@@ -1,2 +1,6 @@
 (** Generate a Dockerfile for building all the opam packages in the build context. *)
-val dockerfile : base:Current_docker.Default.Image.t -> info:Analyse.Analysis.t -> Dockerfile.t
+val dockerfile :
+  base:Current_docker.Default.Image.t ->
+  info:Analyse.Analysis.t ->
+  repo:Current_github.Repo_id.t ->
+  Dockerfile.t

--- a/service/pipeline.ml
+++ b/service/pipeline.ml
@@ -55,8 +55,6 @@ let v ~app () =
   let dockerfile =
     let+ base = Docker.pull ~schedule:weekly "ocurrent/opam:alpine-3.10-ocaml-4.08"
     and+ info = Analyse.examine src in
-    let opam_files = Analyse.Analysis.opam_files info in
-    if opam_files = [] then failwith "No opam files found!";
     Opam_build.dockerfile ~base ~info
   in
   let build = Docker.build ~timeout ~pool ~pull:false ~dockerfile (`Git src) in

--- a/service/pipeline.ml
+++ b/service/pipeline.ml
@@ -54,8 +54,9 @@ let v ~app () =
   let src = Git.fetch (Current.map Github.Api.Commit.id head) in
   let dockerfile =
     let+ base = Docker.pull ~schedule:weekly "ocurrent/opam:alpine-3.10-ocaml-4.08"
+    and+ repo = repo
     and+ info = Analyse.examine src in
-    Opam_build.dockerfile ~base ~info
+    Opam_build.dockerfile ~base ~info ~repo
   in
   let build = Docker.build ~timeout ~pool ~pull:false ~dockerfile (`Git src) in
   let index =


### PR DESCRIPTION
This avoids pinning all the opam packages, relying on the project to be entirely self-contained.

Requested by @avsm.

I'm not sure this is a good idea however, since it means *everything* must be in the duniverse, including depexts.