### PR TITLE
Make two calls to opam depext match each others as much as possible

### DIFF
--- a/service/opam_build.ml
+++ b/service/opam_build.ml
@@ -72,6 +72,6 @@ let dockerfile ~base ~info ~repo =
   run "sudo chown opam /src" @@
   pin_opam_files groups @@
   run "%s opam install %s --dry-run --deps-only -ty | awk '/-> installed/{print $3}' | xargs opam depext -iy" download_cache pkgs @@
-  run "opam depext -y %s" pkgs @@
+  run "opam depext -ty %s" pkgs @@
   copy ~chown:"opam" ~src:["."] ~dst:"/src/" () @@
   run "%s opam install -tv ." caches


### PR DESCRIPTION
Sadly I just realized that #33 is breaking https://github.com/ocaml-ci/ocaml-ci/pull/21 as the second call to `opam depext` doesn't care about which packages are already installed and just go ahead and do as if it were going to install a different set of packages.. This is a problem for packages using a specific version of `llvm` set by the `with-test` flag for instance (which is my case). The first call to `opam depext` installs the proper version but the second call doesn't since `-t` is not given. Adding `-t` should fix this issue.