### PR TITLE
Only call opam depext on the packages being tested if it contains some depexts

### DIFF
--- a/service/opam_build.ml
+++ b/service/opam_build.ml
@@ -64,14 +64,14 @@ let dockerfile ~base ~info ~repo =
     if Analyse.Analysis.is_duniverse info then Printf.sprintf "%s %s" download_cache (build_cache repo)
     else download_cache
   in
-  let pkgs = get_opam_packages groups |> String.concat " " in
+  let pkgs = get_opam_packages groups in
   let open Dockerfile in
   comment "syntax = docker/dockerfile:experimental" @@
   from (Docker.Image.hash base) @@
   workdir "/src" @@
   run "sudo chown opam /src" @@
   pin_opam_files groups @@
-  run "%s opam install %s --dry-run --deps-only -ty | awk '/-> installed/{print $3}' | xargs opam depext -iy" download_cache pkgs @@
-  run "opam depext -ty %s" pkgs @@
+  run "%s opam install %s --dry-run --deps-only -ty | awk '/-> installed/{print $3}' | xargs opam depext -iy" download_cache (pkgs |> String.concat " ") @@
+  List.fold_left (fun acc pkg -> acc @@ run {|test "$(opam show -f depexts: %s)" = "$(printf "\n")" || opam depext -ty %s|} pkg pkg) empty pkgs @@
   copy ~chown:"opam" ~src:["."] ~dst:"/src/" () @@
   run "%s opam install -tv ." caches


### PR DESCRIPTION
Mitigate ocaml/opam-depext#121 encountered by some users of ocaml-ci