### PR TITLE
Only call opam depext on the packages being tested if it contains some depexts

### DIFF
--- a/service/analyse.ml
+++ b/service/analyse.ml
@@ -50,6 +50,7 @@ module Examine = struct
     Current.Process.check_output ~cwd:tmpdir ~switch ~job cmd >|= Stdlib.Result.map @@ fun output ->
     let opam_files =
       String.split_on_char '\n' output
+      |> List.sort String.compare
       |> List.filter (function
           | "" -> false
           | path ->

--- a/service/opam_build.ml
+++ b/service/opam_build.ml
@@ -64,14 +64,14 @@ let dockerfile ~base ~info ~repo =
     if Analyse.Analysis.is_duniverse info then Printf.sprintf "%s %s" download_cache (build_cache repo)
     else download_cache
   in
-  let pkgs = get_opam_packages groups |> String.concat " " in
+  let pkgs = get_opam_packages groups in
   let open Dockerfile in
   comment "syntax = docker/dockerfile:experimental" @@
   from (Docker.Image.hash base) @@
   workdir "/src" @@
   run "sudo chown opam /src" @@
   pin_opam_files groups @@
-  run "%s opam install %s --dry-run --deps-only -ty | awk '/-> installed/{print $3}' | xargs opam depext -iy" download_cache pkgs @@
-  run "opam depext -ty %s" pkgs @@
+  run "%s opam install %s --dry-run --deps-only -ty | awk '/-> installed/{print $3}' | xargs opam depext -iy" download_cache (pkgs |> String.concat " ") @@
+  List.fold_left (fun acc pkg -> acc @@ run {|test "$(opam show -f depexts: %s)" = "$(printf "\n")" || opam depext -ty %s|} pkg pkg) empty pkgs @@
   copy ~chown:"opam" ~src:["."] ~dst:"/src/" () @@
   run "%s opam install -tv ." caches

--- a/service/opam_build.ml
+++ b/service/opam_build.ml
@@ -72,6 +72,8 @@ let dockerfile ~base ~info ~repo =
   run "sudo chown opam /src" @@
   pin_opam_files groups @@
   run "%s opam install %s --dry-run --deps-only -ty | awk '/-> installed/{print $3}' | xargs opam depext -iy" download_cache (pkgs |> String.concat " ") @@
-  List.fold_left (fun acc pkg -> acc @@ run {|test "$(opam show -f depexts: %s)" = "$(printf "\n")" || opam depext -ty %s|} pkg pkg) empty pkgs @@
+  crunch_list (List.map (fun pkg ->
+      run {|test "$(opam show -f depexts: %s)" = "$(printf "\n")" || opam depext -ty %s|} pkg pkg) pkgs
+    ) @@
   copy ~chown:"opam" ~src:["."] ~dst:"/src/" () @@
   run "%s opam install -tv ." caches


### PR DESCRIPTION
Rebased #38, plus sort the output from find to make caching more reliable.