### PR TITLE
Add a resource pool for lint jobs

### DIFF
--- a/service/lint.ml
+++ b/service/lint.ml
@@ -1,5 +1,5 @@
 open Current.Syntax
-module Docker = Current_docker.Default
+module Docker = Conf.Builder_amd1
 
 let format_dockerfile ~base ~ocamlformat_version =
   let open Dockerfile in
@@ -15,6 +15,6 @@ let v_from_opam ~ocamlformat_version ~base ~src =
     format_dockerfile ~base ~ocamlformat_version
   in
   let img =
-    Docker.build ~label:"OCamlformat" ~pull:false ~dockerfile (`Git src)
+    Docker.build ~label:"OCamlformat" ~pool:Docker.pool ~pull:false ~dockerfile (`Git src)
   in
   Docker.run ~label:"lint" img ~args:[ "sh"; "-c"; "dune build @fmt || (echo \"dune build @fmt failed\"; exit 2)" ]

--- a/service/lint.mli
+++ b/service/lint.mli
@@ -1,4 +1,4 @@
-module Docker = Current_docker.Default
+module Docker = Conf.Builder_amd1
 
 val v_from_opam :
   ocamlformat_version:string Current.t ->

--- a/service/pipeline.ml
+++ b/service/pipeline.ml
@@ -47,7 +47,7 @@ let lint ~analysis ~src =
   |> Current.map Analyse.Analysis.ocamlformat_version
   |> Current.option_map (fun ocamlformat_version ->
       let base =
-        Docker.pull ~schedule:weekly "ocurrent/opam:alpine-3.10-ocaml-4.08"
+        Conf.Builder_amd1.pull ~schedule:weekly "ocurrent/opam:alpine-3.10-ocaml-4.08"
       in
       Lint.v_from_opam ~ocamlformat_version ~base ~src
     )


### PR DESCRIPTION
Avoids overloading the machine if we need to rebuild lots of them at once for some reason.